### PR TITLE
Fixes 'ovs_neutron_agent doesn't start on Windows because of validate…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -45,3 +45,4 @@ python-novaclient>=2.28.1
 # Windows-only requirements
 pywin32;sys_platform=='win32'
 wmi;sys_platform=='win32'
+netifaces>=0.10.4;sys_platform=='win32'


### PR DESCRIPTION
…_local_ip'

Change I4b4527c28d0738890e33b343c9e17941e780bc24 introduced a validate_local_ip
sanity check for the local_ip to see that it belongs to the host.
This method uses linux specific implementation that fails on windows.

This patch fixes this bug by adding a implementation for validate_local_ip
that works on windows as well, using netifaces.

Change-Id: Ia8299512687d9d7135fe013fbb38f2b28d54125d
Closes-Bug: #1497940
